### PR TITLE
Add ability to set an offset of the VirtualizingGridPanel children

### DIFF
--- a/Program Viewer 3.0/MainWindow.xaml
+++ b/Program Viewer 3.0/MainWindow.xaml
@@ -20,7 +20,7 @@
             </Grid.ColumnDefinitions>
 
             <Rectangle Fill="{DynamicResource HotRect.Background}" HorizontalAlignment="Right" Width="99" ScrollViewer.VerticalScrollBarVisibility="Hidden" StrokeLineJoin="Round" StrokeEndLineCap="Triangle" StrokeThickness="1" Stroke="Black"/>
-            
+
             <tb:TaskbarIcon x:Name="TaskbarIcon" ToolTipText="Program Viewer 3.0" IconSource="Pictures/Icon.ico">
                 <tb:TaskbarIcon.ContextMenu>
                     <ContextMenu Background="{DynamicResource CustomWindow.Background}" Foreground="White">
@@ -28,7 +28,7 @@
                     </ContextMenu>
                 </tb:TaskbarIcon.ContextMenu>
             </tb:TaskbarIcon>
-            
+
             <!--Hot ListView-->
             <controls:VirtualizingGridPanel x:Name="HotGridPanel" ColumnsCount="1" Width="105" Margin="0,0,-4,0" HorizontalAlignment="Right" ItemSize="105,110" PanelOpacityMask="{StaticResource GridPanel.OpacityMask}">
                 <controls:VirtualizingGridPanel.CacheMode>
@@ -43,7 +43,7 @@
             </controls:PiButton>
 
             <!--Desktop ListView-->
-            <controls:VirtualizingGridPanel x:Name="DesktopGridPanel" ColumnsCount="4" HorizontalAlignment="Left" Width="420" Margin="50,0,0,1" ItemSize="105,110" ScrollOffset="120" PanelOpacityMask="{StaticResource GridPanel.OpacityMask}">
+            <controls:VirtualizingGridPanel x:Name="DesktopGridPanel" ColumnsCount="4" HorizontalAlignment="Left" HorizontalContentAlignment="Left" Width="460" Margin="31,0,0,1" ItemSize="105,110" ScrollOffset="120" ChildItemsHorizontalOffset="19" PanelOpacityMask="{StaticResource GridPanel.OpacityMask}">
                 <controls:VirtualizingGridPanel.CacheMode>
                     <BitmapCache/>
                 </controls:VirtualizingGridPanel.CacheMode>

--- a/Program Viewer 3.0/Managers/AnimationManager.cs
+++ b/Program Viewer 3.0/Managers/AnimationManager.cs
@@ -16,17 +16,17 @@ namespace ProgramViewer3.Managers
 		private readonly Storyboard menuShrinkSB = new Storyboard();
 		private readonly Storyboard menuExpandSB = new Storyboard();
 		//private readonly Storyboard addItemWindowShowSB = new Storyboard();
-  //      private readonly Storyboard addItemWindowHideSB = new Storyboard();
-        private readonly Storyboard contextMenuShowSB = new Storyboard();
+		//private readonly Storyboard addItemWindowHideSB = new Storyboard();
+		private readonly Storyboard contextMenuShowSB = new Storyboard();
 		private readonly Storyboard contextMenuHideSB = new Storyboard();
 
 		private readonly Dictionary<string, Storyboard> storyboards = new Dictionary<string, Storyboard>();
 
-		private readonly ExponentialEase exponentialEaseIn = new ExponentialEase
+		public static readonly ExponentialEase ExponentialEaseIn = new ExponentialEase
 		{
 			EasingMode = EasingMode.EaseIn
 		};
-		private readonly ExponentialEase exponentialEaseOut = new ExponentialEase
+		public static readonly ExponentialEase ExponentialEaseOut = new ExponentialEase
 		{
 			EasingMode = EasingMode.EaseOut
 		};
@@ -51,10 +51,10 @@ namespace ProgramViewer3.Managers
 
 			mainWindow.RefreshControlsAfterThemeChanging();
 
-            var settingsWidthDA = CreateDoubleAnimation(MenuGridResizeArea.X, resizeDuration, "MenuGrid", "Width", exponentialEaseIn);
-            var opacityDA = CreateDoubleAnimation(0, resizeDuration, "DesktopGridPanel", "Opacity", exponentialEaseIn);
-            var contextMenuDA = CreateDoubleAnimation(1, addItemWindowSHAnimDuration, "PiContextMenu", "Opacity", exponentialEaseIn);
-			var menuShadowOpacityDA = CreateDoubleAnimation(0, resizeDuration, "MenuGrid", "(Effect).Opacity", exponentialEaseIn);
+            var settingsWidthDA = CreateDoubleAnimation(MenuGridResizeArea.X, resizeDuration, "MenuGrid", "Width", ExponentialEaseIn);
+            var opacityDA = CreateDoubleAnimation(0, resizeDuration, "DesktopGridPanel", "Opacity", ExponentialEaseIn);
+            var contextMenuDA = CreateDoubleAnimation(1, addItemWindowSHAnimDuration, "PiContextMenu", "Opacity", ExponentialEaseIn);
+			var menuShadowOpacityDA = CreateDoubleAnimation(0, resizeDuration, "MenuGrid", "(Effect).Opacity", ExponentialEaseIn);
 
 			var menuRectCA = CreateMenuVerticalRectExpandAnimation();
 
@@ -65,10 +65,10 @@ namespace ProgramViewer3.Managers
 
             contextMenuShowSB.Children.Add(contextMenuDA);
 
-			settingsWidthDA = CreateDoubleAnimation(MenuGridResizeArea.Y, resizeDuration, "MenuGrid", "Width", exponentialEaseOut);
-			opacityDA = CreateDoubleAnimation(1, resizeDuration, "DesktopGridPanel", "Opacity", exponentialEaseOut);
-			menuShadowOpacityDA = CreateDoubleAnimation(0.5, resizeDuration, "MenuGrid", "(Effect).Opacity", exponentialEaseOut);
-            contextMenuDA = CreateDoubleAnimation(0, addItemWindowSHAnimDuration, "PiContextMenu", "Opacity", exponentialEaseOut);
+			settingsWidthDA = CreateDoubleAnimation(MenuGridResizeArea.Y, resizeDuration, "MenuGrid", "Width", ExponentialEaseOut);
+			opacityDA = CreateDoubleAnimation(1, resizeDuration, "DesktopGridPanel", "Opacity", ExponentialEaseOut);
+			menuShadowOpacityDA = CreateDoubleAnimation(0.5, resizeDuration, "MenuGrid", "(Effect).Opacity", ExponentialEaseOut);
+            contextMenuDA = CreateDoubleAnimation(0, addItemWindowSHAnimDuration, "PiContextMenu", "Opacity", ExponentialEaseOut);
 
 			menuRectCA = CreateMenuVerticalRectShrinkAnimation();
 
@@ -106,7 +106,18 @@ namespace ProgramViewer3.Managers
             return da;
         }
 
-		private ColorAnimation CreateColorAnimation(Color to, TimeSpan duration,
+		public static ColorAnimation CreateColorAnimation(Color to, TimeSpan duration,
+			string targetProperty, string propertyPath, IEasingFunction easingFunction)
+		{
+			ColorAnimation ca = new ColorAnimation(to, duration);
+			ca.SetValue(Storyboard.TargetNameProperty, targetProperty);
+			Storyboard.SetTargetProperty(ca, new PropertyPath(propertyPath));
+			ca.EasingFunction = easingFunction;
+
+			return ca;
+		}
+
+		public static ColorAnimation CreateColorAnimation(Color to, Duration duration,
 			string targetProperty, string propertyPath, IEasingFunction easingFunction)
 		{
 			ColorAnimation ca = new ColorAnimation(to, duration);
@@ -195,12 +206,12 @@ namespace ProgramViewer3.Managers
 
 		private ColorAnimation CreateMenuVerticalRectShrinkAnimation()
 		{
-			return CreateColorAnimation((mainWindow.FindResource("CustomWindow.TitleBar.Background") as SolidColorBrush).Color, WindowResizeDuration, "SettingsVerticalRect", "(Rectangle.Fill).(SolidColorBrush.Color)", exponentialEaseOut);
+			return CreateColorAnimation((mainWindow.FindResource("CustomWindow.TitleBar.Background") as SolidColorBrush).Color, WindowResizeDuration, "SettingsVerticalRect", "(Rectangle.Fill).(SolidColorBrush.Color)", ExponentialEaseOut);
 		}
 
 		private ColorAnimation CreateMenuVerticalRectExpandAnimation()
 		{
-			return CreateColorAnimation((mainWindow.FindResource("SettingVerticalRect.ExpandBackground") as SolidColorBrush).Color, WindowResizeDuration, "SettingsVerticalRect", "(Rectangle.Fill).(SolidColorBrush.Color)", exponentialEaseIn);
+			return CreateColorAnimation((mainWindow.FindResource("SettingVerticalRect.ExpandBackground") as SolidColorBrush).Color, WindowResizeDuration, "SettingsVerticalRect", "(Rectangle.Fill).(SolidColorBrush.Color)", ExponentialEaseIn);
 		}
 
 		public void ToggleMenu(bool value)

--- a/Program Viewer 3.0/Managers/SettingsManager.cs
+++ b/Program Viewer 3.0/Managers/SettingsManager.cs
@@ -20,6 +20,7 @@ namespace ProgramViewer3.Managers
 
 			InitFieldFromJson("RedirectMessageLogging", true);
 			InitFieldFromJson("LastUsedTheme", ThemeManager.DefaultThemeName);
+			InitFieldFromJson("", ThemeManager.DefaultThemeName);
 		}
 
 		public void CloseManager()

--- a/Program Viewer 3.0/Managers/ThemeManager.cs
+++ b/Program Viewer 3.0/Managers/ThemeManager.cs
@@ -66,7 +66,7 @@ namespace ProgramViewer3.Managers
 			DefaultResourceCollection = null;
 			DefaultResourceCollection = new List<ResourceDictionary>(collection);
 
-			if (name != DefaultThemeName && name != null && name != string.Empty)
+			if (name != DefaultThemeName && name is null == false && name != string.Empty)
 			{
 				var resource = GetThemeRecource(name);
 				if (resource != null)

--- a/Program Viewer 3.0/PiButton.xaml
+++ b/Program Viewer 3.0/PiButton.xaml
@@ -24,7 +24,7 @@
         </EventTrigger>
     </UserControl.Triggers>
 
-    <Grid MouseDown="Grid_MouseDown">
+    <Grid x:Name="ButtonGrid" MouseDown="Grid_MouseDown">
         <Image x:Name="ButtonImage" Source="{Binding Path=Source}"/>
         <TextBlock x:Name="ButtonText" Text="{Binding Path=Text}" Foreground="{Binding Path=Foreground}"
                    HorizontalAlignment="{Binding Path=TextHorizontalAlignment}"
@@ -43,7 +43,7 @@
         <Grid.Triggers>
             <EventTrigger RoutedEvent="MouseEnter">
                 <BeginStoryboard>
-                    <Storyboard>
+                    <Storyboard x:Name="MouseEnterBackgroundStoryboard" FillBehavior="Stop" Completed="MouseEnterBackgroundStoryboard_Completed">
                         <ColorAnimation To="{Binding Path=HoverBrush.Color}" Duration="{Binding Path=HoverDuration}" Storyboard.TargetProperty="(Grid.Background).(SolidColorBrush.Color)">
                             <ColorAnimation.EasingFunction>
                                 <ExponentialEase EasingMode="EaseOut" />
@@ -54,11 +54,11 @@
             </EventTrigger>
             <EventTrigger RoutedEvent="MouseLeave">
                 <BeginStoryboard>
-                    <Storyboard>
+                    <Storyboard x:Name="MouseLeaveBackgroundStoryboard" FillBehavior="Stop" Completed="MouseLeaveBackgroundStoryboard_Completed">
                         <ColorAnimation To="{Binding Path=Background.Color}" Duration="{Binding Path=HoverDuration}" Storyboard.TargetProperty="(Grid.Background).(SolidColorBrush.Color)">
-                        <ColorAnimation.EasingFunction>
-                            <ExponentialEase EasingMode="EaseOut" />
-                        </ColorAnimation.EasingFunction>
+                            <ColorAnimation.EasingFunction>
+                                <ExponentialEase EasingMode="EaseOut" />
+                            </ColorAnimation.EasingFunction>
                         </ColorAnimation>
                     </Storyboard>
                 </BeginStoryboard>

--- a/Program Viewer 3.0/PiButton.xaml.cs
+++ b/Program Viewer 3.0/PiButton.xaml.cs
@@ -1,17 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using System.Windows.Media.Animation;
+using ProgramViewer3.Managers;
 
 namespace ProgramViewer3
 {
@@ -73,15 +66,35 @@ namespace ProgramViewer3
 			set => SetValue(TextMarginProperty, value);
 		}
 
+		public event RoutedEventHandler Click;
+
 		public PiButton()
 		{
 			InitializeComponent();
+
 			LostMouseCapture += PiButton_LostMouseCapture;
 		}
 
 		private void PiButton_LostMouseCapture(object sender, MouseEventArgs e) => Opacity = 1;
 
-		public event RoutedEventHandler Click;
 		private void Grid_MouseDown(object sender, MouseButtonEventArgs e) => Click?.Invoke(this, e);
+
+		private void MouseEnterBackgroundStoryboard_Completed(object sender, EventArgs e)
+		{
+			if (HoverBrush is null == false)
+			{
+				(ButtonGrid.Background as SolidColorBrush).Color = (HoverBrush as SolidColorBrush).Color;
+			}
+			ButtonGrid.BeginAnimation(BackgroundProperty, null);
+		}
+
+		private void MouseLeaveBackgroundStoryboard_Completed(object sender, EventArgs e)
+		{
+			if (Background is null == false)
+			{
+				(ButtonGrid.Background as SolidColorBrush).Color = (Background as SolidColorBrush).Color;
+			}
+			ButtonGrid.BeginAnimation(BackgroundProperty, null);
+		}
 	}
 }

--- a/Program Viewer 3.0/ProgramViewer3.csproj
+++ b/Program Viewer 3.0/ProgramViewer3.csproj
@@ -70,6 +70,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Fix bug which occurs when we set the HorizontalContentAlignment for the VirtualizingGridPanel instance but it does not actually change the children horizontal alignment
Fix bug when a new theme is applied and the desktopResizeButton does not change its Background color

Signed-off-by: PandrPi <nicecrafter0507@gmail.com>