### PR TITLE
Fix failed items save bug. When Windows OS is shutting down it closes…

### DIFF
--- a/Program Viewer 3.0/FileToIcon.cs
+++ b/Program Viewer 3.0/FileToIcon.cs
@@ -315,12 +315,33 @@ namespace ProgramViewer3
 
 			//Bugfixes by h32
 
+			// Causes "The calling thread cannot access this object because a different thread owns it."
+			// exception but not every time the method is called
+			//if (dispatcher)
+			//{
+			//	target.Dispatcher.BeginInvoke(DispatcherPriority.Background,
+			//	new ThreadStart(delegate
+			//	{
+			//		//UI Thread
+			//		var delta = target.Height - height;
+			//		var newWidth = width > target.Width ? (int)target.Width : width;
+			//		var newHeight = height > target.Height ? (int)target.Height : height;
+			//		Int32Rect outRect = new Int32Rect(0, (int)(delta >= 0 ? delta : 0) / 2, newWidth, newWidth);
+			//		try
+			//		{
+			//			target.WritePixels(outRect, bits, stride, 0);
+			//		}
+			//		catch
+			//		{
+			//			System.Diagnostics.Debugger.Break();
+			//		}
+			//	}));
+			//}
+
 			if (dispatcher)
 			{
-				target.Dispatcher.BeginInvoke(DispatcherPriority.Background,
-				new ThreadStart(delegate
+				target.Dispatcher.Invoke(DispatcherPriority.Background, new Action(() =>
 				{
-					//UI Thread
 					var delta = target.Height - height;
 					var newWidth = width > target.Width ? (int)target.Width : width;
 					var newHeight = height > target.Height ? (int)target.Height : height;

--- a/Program Viewer 3.0/MainWindow.xaml
+++ b/Program Viewer 3.0/MainWindow.xaml
@@ -19,7 +19,7 @@
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
 
-            <Rectangle Fill="{DynamicResource HotRect.Background}" HorizontalAlignment="Right" Width="99" ScrollViewer.VerticalScrollBarVisibility="Hidden" StrokeLineJoin="Round" StrokeEndLineCap="Triangle" StrokeThickness="1" Stroke="Black"/>
+            <Rectangle Fill="{DynamicResource HotRect.Background}" HorizontalAlignment="Right" Width="99" ScrollViewer.VerticalScrollBarVisibility="Hidden" StrokeLineJoin="Round" StrokeEndLineCap="Triangle" StrokeThickness="0"/>
 
             <tb:TaskbarIcon x:Name="TaskbarIcon" ToolTipText="Program Viewer 3.0" IconSource="Pictures/Icon.ico">
                 <tb:TaskbarIcon.ContextMenu>

--- a/Program Viewer 3.0/Managers/LogManager.cs
+++ b/Program Viewer 3.0/Managers/LogManager.cs
@@ -6,10 +6,15 @@ namespace ProgramViewer3.Managers
 	public static class LogManager
 	{
 		private static readonly string logFileName = Path.Combine(ItemManager.ApplicationPath, "logout.txt");
-			    
+
 		private static TextWriter defaultWriter;
 		private static StreamWriter newWriter;
 
+		/// <summary>
+		/// Initializes the LogManager
+		/// </summary>
+		/// <param name="redirectLogging">Determines whether to redirect the Console output
+		/// to our own log file</param>
 		public static void Initiallize(bool redirectLogging)
 		{
 			defaultWriter = Console.Out;
@@ -17,7 +22,7 @@ namespace ProgramViewer3.Managers
 			{
 				try
 				{
-					if (!File.Exists(logFileName)) File.Create(logFileName).Close();
+					File.WriteAllText(logFileName, string.Empty);
 					newWriter = new StreamWriter(logFileName, false);
 					Console.SetOut(newWriter);
 				}
@@ -29,16 +34,30 @@ namespace ProgramViewer3.Managers
 			}
 		}
 
+		/// <summary>
+		/// Sets Console.Out property to the default Console writer stream 
+		/// </summary>
 		public static void Close()
 		{
 			Console.SetOut(defaultWriter);
 			newWriter?.Close();
 		}
 
+		/// <summary>
+		/// Writes the specified message object to the Console output stream
+		/// </summary>
+		/// <param name="message"></param>
 		public static void Write(string message)
 		{
+			const string writeFormat = "{0} : {1}";
 			string date = DateTime.Now.ToString();
-			Console.WriteLine($"{date} : {message}");
+			Console.WriteLine(writeFormat, date, message);
+		}
+
+		public static void Error(Exception exception)
+		{
+			const string errorFormat = "Message: {0}.\nStack trace: {1}";
+			Write(string.Format(errorFormat, exception.Message, exception.StackTrace));
 		}
 	}
 }

--- a/Program Viewer 3.0/Managers/ThemeManager.cs
+++ b/Program Viewer 3.0/Managers/ThemeManager.cs
@@ -28,7 +28,7 @@ namespace ProgramViewer3.Managers
 			DefaultThemeDictionary = DefaultResourceCollection.Where(i => i.Source.OriginalString.Contains(Regex.Replace(DefaultThemeName, @"\s+", ""))).First();
 			DefaultResourcesNumber = DefaultResourceCollection.Count;
 
-			CacheManager.InitiallizeDirectory(ThemeFolder);
+			CacheManager.InitializeDirectory(ThemeFolder);
 
 			LoadThemes();
 		}
@@ -54,6 +54,7 @@ namespace ProgramViewer3.Managers
 				}
 				catch (Exception e)
 				{
+					LogManager.Error(e);
 					MessageBox.Show(e.Message, $"{e.GetType().Name} occured in file 'Themes/{current.Name}'");
 				}
 			}
@@ -140,7 +141,7 @@ namespace ProgramViewer3.Managers
 
 			private static T GetResource<T>(ResourceDictionary resource, string key)
 			{
-				return resource.Contains(key) ? (T)resource[key] : (T)ThemeManager.DefaultThemeDictionary[key];
+				return resource.Contains(key) ? (T)resource[key] : (T)DefaultThemeDictionary[key];
 			}
 		}
 	}

--- a/Program Viewer 3.0/Resources/DefaultTheme.xaml
+++ b/Program Viewer 3.0/Resources/DefaultTheme.xaml
@@ -11,17 +11,17 @@
     <DropShadowEffect x:Key="GridPanel.Item.Image.Shadow" ShadowDepth="8"/>
 
     <LinearGradientBrush x:Key="DesktopRect.Background" EndPoint="0.5,1" StartPoint="0.5,0">
-        <GradientStop Color="#FF5D747E" Offset="0"/>
-        <GradientStop Color="#FF12131A" Offset="1"/>
+        <GradientStop Color="#FF8CB3C3" Offset="0"/>
+        <GradientStop Color="#FF646B9C" Offset="1"/>
     </LinearGradientBrush>
     <SolidColorBrush x:Key="DesktopRect.ResizeButton.Background" Color="#FFFFB900"/>
     <SolidColorBrush x:Key="DesktopRect.ResizeButton.Border" Color="#FF232323"/>
-    <Thickness x:Key="DesktopRect.ResizeButton.Border.Thickness" Left="1" Right="1"/>
+    <Thickness x:Key="DesktopRect.ResizeButton.Border.Thickness"  Left="0" Right="0"/>
     <SolidColorBrush x:Key="DesktopRect.ResizeButton.Hover.Background" Color="#FFBEE6FD"/>
 
     <LinearGradientBrush x:Key="HotRect.Background" EndPoint="0.5,1" StartPoint="0.5,0">
-        <GradientStop Color="#FF688293" Offset="0"/>
-        <GradientStop Color="#FF2C363C" Offset="1"/>
+        <GradientStop Color="#FF8CB3C3" Offset="0"/>
+        <GradientStop Color="#FF646B9C" Offset="1"/>
     </LinearGradientBrush>
 
     <SolidColorBrush x:Key="SettingVerticalRect.ExpandBackground" Color="#FF6F8C9C"/>

--- a/Program Viewer 3.0/VirtualizingGridPanel.cs
+++ b/Program Viewer 3.0/VirtualizingGridPanel.cs
@@ -351,7 +351,7 @@ namespace ProgramViewer3
 						var panel = (StackPanel)RowRenderer.Children[columnIndex];
 						if (needToFill)
 						{
-							Managers.ItemData itemData = ItemSource[itemIndex];
+							ItemData itemData = ItemSource[itemIndex];
 							(panel.Children[0] as Image).Source = itemData.ImageData;
 							(panel.Children[1] as TextBlock).Text = itemData.Title;
 							itemsInRow++;
@@ -392,6 +392,7 @@ namespace ProgramViewer3
 				}
 				catch (Exception e)
 				{
+					LogManager.Error(e);
 					MessageBox.Show(e.StackTrace, e.Message);
 				}
 			}
@@ -520,7 +521,7 @@ namespace ProgramViewer3
 		/// <param name="elementsInRow">The number of elements in the current row</param>
 		private void ReplaceItemHighlighter(Point offset, double elementsInRow)
 		{
-			offset.X = RoundToLowerMultiple((int)offset.X, (int)ItemSize.Width);
+			offset.X = RoundToLowerMultiple((int)(offset.X - ChildItemsHorizontalOffset), (int)ItemSize.Width);
 			if (offset.X > (elementsInRow - 1) * ItemSize.Width)
 			{
 				StartItemHighlighter_FadeAnimation(false);


### PR DESCRIPTION
… all active processes including our app process. When our app closes it saves items from the HotGridPanel to the json file. However, sometimes the app closes before the save process is complete so the HotItems.json file is corrupted and the next time the app starts the user does not see the items in HotGridPanel. We fix the bug by allowing the app to save all the necessary data only when needed.

Get rid of cached images inside the IconExtractor class
Rewrite LoadIconFromImageFile method of IconExtractor class so that it does not use FileToIconConverter class anymore. This gives us a slight increase in performance because the FileToIconConverter class uses unnecessary multithreading.
Add more comments for code
Add more method descriptions
Rename some variables and methods so that they can better represent their purpose

Signed-off-by: PandrPi <nicecrafter0507@gmail.com>